### PR TITLE
Updated Jinja master template

### DIFF
--- a/devtools/commands/quickstart_jinja/master.jinja
+++ b/devtools/commands/quickstart_jinja/master.jinja
@@ -59,6 +59,6 @@
     </div>
 
     <script src="http://code.jquery.com/jquery.js"></script>
-    <script src="${tg.url('/javascript/bootstrap.min.js')}"></script>
+    <script src="{{ tg.url('/javascript/bootstrap.min.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
The line of code that included bootstrap javascript was still
a Genshi instruction, changed to the appropriate Jinja2
equivalent.

This fixes issue #5

https://github.com/TurboGears/tg2devtools/issues/5
