### PR TITLE
Make `gearbox tgshell` work again with IPython 6.0

### DIFF
--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -123,7 +123,7 @@ class ShellCommand(Command):
                 except ImportError:
                     # ipython >= 0.11
                     from IPython.frontend.terminal.embed import InteractiveShellEmbed
-                shell = InteractiveShellEmbed(banner2=banner)
+                shell = InteractiveShellEmbed.instance(banner2=banner)
             except ImportError:
                 # ipython < 0.11
                 from IPython.Shell import IPShellEmbed

--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -130,7 +130,7 @@ class ShellCommand(Command):
                 shell = IPShellEmbed()
                 shell.set_banner(shell.IP.BANNER + '\n\n' + banner)
 
-            shell(local_ns=locs, global_ns={})
+            shell(local_ns=locs)
         except ImportError:
             import code
             py_prefix = sys.platform.startswith('java') and 'J' or 'P'

--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -117,8 +117,12 @@ class ShellCommand(Command):
 
             # try to use IPython if possible
             try:
-                # ipython >= 0.11
-                from IPython.frontend.terminal.embed import InteractiveShellEmbed
+                try:
+                    # ipython >= 1.0
+                    from IPython.terminal.embed import InteractiveShellEmbed
+                except ImportError:
+                    # ipython >= 0.11
+                    from IPython.frontend.terminal.embed import InteractiveShellEmbed
                 shell = InteractiveShellEmbed(banner2=banner)
             except ImportError:
                 # ipython < 0.11


### PR DESCRIPTION
I've tested the changes with IPython version 0.11 ~ 5.0 on Python 2.7, and IPython 6.0 on Python 3.5. With all of these, `gearbox tgshell` starts without making a fuss.