### PR TITLE
WebTest documentation URL update

### DIFF
--- a/devtools/gearbox/quickstart/template/+package+/tests/functional/test_root.py_tmpl
+++ b/devtools/gearbox/quickstart/template/+package+/tests/functional/test_root.py_tmpl
@@ -7,7 +7,7 @@ This is an example of how functional tests can be written for controllers.
 As opposed to a unit-test, which test a small unit of functionality,
 functional tests exercise the whole application and its WSGI stack.
 
-Please read http://pythonpaste.org/webtest/ for more information.
+Please read https://webtest.readthedocs.io/ for more information.
 
 """
 


### PR DESCRIPTION
Documentation for WebTest is not available anymore on http://pythonpaste.org/webtest/ 
Change to https://webtest.readthedocs.io/