### PR TITLE
Issue #15: Fixed model rendering for zope.sqlalchemy

### DIFF
--- a/devtools/gearbox/quickstart/template/+package+/model/__init__.py_tmpl
+++ b/devtools/gearbox/quickstart/template/+package+/model/__init__.py_tmpl
@@ -2,14 +2,14 @@
 {{if sqlalchemy}}
 """The application's model objects"""
 
-from zope.sqlalchemy import ZopeTransactionExtension
+from zope.sqlalchemy import ZopeTransactionEvents
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
 # Global session manager: DBSession() returns the Thread-local
 # session object appropriate for the current web request.
 maker = sessionmaker(autoflush=True, autocommit=False,
-                     extension=ZopeTransactionExtension())
+                     extension=ZopeTransactionEvents())
 DBSession = scoped_session(maker)
 
 # Base class for all of our model classes: By default, the data model is

--- a/devtools/gearbox/quickstart/template/setup.py_tmpl
+++ b/devtools/gearbox/quickstart/template/setup.py_tmpl
@@ -46,7 +46,7 @@ install_requires = [
     "Mako",
     {{endif}}
     {{if sqlalchemy}}
-    "zope.sqlalchemy >= 0.4",
+    "zope.sqlalchemy >= 1.2",
     "sqlalchemy",
     {{endif}}
     {{if sqlalchemy and migrations}}


### PR DESCRIPTION
The latest released version of zope.sqlalchemy (1.2) changed the
name of ZopeTransactionExtension class to ZopeTransactionEvents,
which breaks apps generated with gearbox quickstart.  This patch
updates the name to work with zope.sqlalchemy 1.2 and >

This PR fixes issue #15 