### PR TITLE
Improve robustness of tests with sqlalchemy

### DIFF
--- a/devtools/gearbox/quickstart/template/+package+/model/__init__.py_tmpl
+++ b/devtools/gearbox/quickstart/template/+package+/model/__init__.py_tmpl
@@ -49,6 +49,7 @@ def init_model(engine):
     """Call me before using any of the tables or classes in the model."""
 
 {{if sqlalchemy}}
+    DBSession.remove()
     DBSession.configure(bind=engine)
 
     # If you are using reflection to introspect your database and create

--- a/devtools/gearbox/quickstart/template/+package+/tests/models/__init__.py_tmpl
+++ b/devtools/gearbox/quickstart/template/+package+/tests/models/__init__.py_tmpl
@@ -4,6 +4,8 @@
 from nose.tools import eq_
 
 {{if sqlalchemy}}
+import transaction
+
 from {{package}}.model import DBSession
 {{elif ming}}
 from tg import config
@@ -64,7 +66,7 @@ class ModelTest(object):
                 # On MongoDB drop database
                 datastore.conn.drop_database(datastore.db)
             {{elif sqlalchemy}}
-            DBSession.rollback()
+            transaction.abort()
             {{endif}}
             raise
 
@@ -79,7 +81,7 @@ class ModelTest(object):
             # On MongoDB drop database
             datastore.conn.drop_database(datastore.db)
         {{elif sqlalchemy}}
-        DBSession.rollback()
+        transaction.abort()
         {{endif}}
 
     def do_get_dependencies(self):

--- a/devtools/gearbox/quickstart/template/+package+/websetup/bootstrap.py_tmpl
+++ b/devtools/gearbox/quickstart/template/+package+/websetup/bootstrap.py_tmpl
@@ -15,6 +15,7 @@ def bootstrap(command, conf, vars):
     {{if auth == "sqlalchemy"}}
     from sqlalchemy.exc import IntegrityError
     try:
+        transaction.begin()
         u = model.User()
         u.user_name = 'manager'
         u.display_name = 'Example manager'

--- a/devtools/gearbox/quickstart/template/+package+/websetup/schema.py_tmpl
+++ b/devtools/gearbox/quickstart/template/+package+/websetup/schema.py_tmpl
@@ -17,6 +17,7 @@ def setup_schema(command, conf, vars):
     from {{package}} import model
     # <websetup.websetup.schema.after.model.import>
 
+    transaction.begin()
     # <websetup.websetup.schema.before.metadata.create_all>
     print("Creating tables")
     model.metadata.create_all(bind=config['tg.app_globals'].sa_engine)


### PR DESCRIPTION
This PR fixes some issues with quickstarted projects:

* `model.init_model()` could be called multiple times through loading the app (functional tests) or `tests.models.setup_db()` but wouldn't dispose of the previous session
* mixed use of `transaction` and `DBSession` APIs to manage transactions
* `websetup` assumes that transactions are in the `ACTIVE` state but this doesn't hold true if `teardown_db()` was called before

This would cause functional tests to fail setting up the test application if `setup_db()` was called in a previous test, which can easily be tested by renaming the `tests.functional` to e.g. `tests.zzz_functional` in a quickstarted project and then running the test suite.

NB: Having slept a night over it, a different way to address this would be to have exactly one test app, and one call to `setup_db()` prior to all tests but I'm not sure how feasible this is.