### PR TITLE
Start IPython manually instead of embedding (fixes variable scoping issues with gearbox tgshell IPython sessions)

### DIFF
--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -123,12 +123,16 @@ class ShellCommand(Command):
             # try to use IPython if possible
             try:
                 try:
-                    # ipython >= 1.0
-                    from IPython.terminal.embed import InteractiveShellEmbed
+                    from IPython import start_ipython
+                    from IPython.terminal.ipapp import load_default_config
+                    config = load_default_config()
+                    config.TerminalInteractiveShell.banner1 = banner
+                    start_ipython(argv=[], user_ns=locs, config=config)
+
                 except ImportError:
                     # ipython >= 0.11
                     from IPython.frontend.terminal.embed import InteractiveShellEmbed
-                shell = InteractiveShellEmbed.instance(banner2=banner)
+                    shell = InteractiveShellEmbed.instance(banner2=banner)
             except ImportError:
                 # ipython < 0.11
                 from IPython.Shell import IPShellEmbed

--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -120,12 +120,12 @@ class ShellCommand(Command):
             if disable_ipython:
                 raise ImportError()
 
-	    from IPython import start_ipython
-	    from IPython.terminal.ipapp import load_default_config
-	    config = load_default_config()
-	    config.TerminalInteractiveShell.banner1 = banner
-	    start_ipython(argv=[], user_ns=locs, config=config)
-	    return
+            from IPython import start_ipython
+            from IPython.terminal.ipapp import load_default_config
+            config = load_default_config()
+            config.TerminalInteractiveShell.banner1 = banner
+            start_ipython(argv=[], user_ns=locs, config=config)
+            return
 
         except ImportError:
             import code

--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -120,27 +120,13 @@ class ShellCommand(Command):
             if disable_ipython:
                 raise ImportError()
 
-            # try to use IPython if possible
-            try:
-                try:
-                    from IPython import start_ipython
-                    from IPython.terminal.ipapp import load_default_config
-                    config = load_default_config()
-                    config.TerminalInteractiveShell.banner1 = banner
-                    start_ipython(argv=[], user_ns=locs, config=config)
-                    return
+	    from IPython import start_ipython
+	    from IPython.terminal.ipapp import load_default_config
+	    config = load_default_config()
+	    config.TerminalInteractiveShell.banner1 = banner
+	    start_ipython(argv=[], user_ns=locs, config=config)
+	    return
 
-                except ImportError:
-                    # ipython >= 0.11
-                    from IPython.frontend.terminal.embed import InteractiveShellEmbed
-                    shell = InteractiveShellEmbed.instance(banner2=banner)
-            except ImportError:
-                # ipython < 0.11
-                from IPython.Shell import IPShellEmbed
-                shell = IPShellEmbed()
-                shell.set_banner(shell.IP.BANNER + '\n\n' + banner)
-
-            shell(local_ns=locs)
         except ImportError:
             import code
             py_prefix = sys.platform.startswith('java') and 'J' or 'P'

--- a/devtools/gearbox/tgshell.py
+++ b/devtools/gearbox/tgshell.py
@@ -128,6 +128,7 @@ class ShellCommand(Command):
                     config = load_default_config()
                     config.TerminalInteractiveShell.banner1 = banner
                     start_ipython(argv=[], user_ns=locs, config=config)
+                    return
 
                 except ImportError:
                     # ipython >= 0.11


### PR DESCRIPTION
Prevents a category of scoping issues which happen as a result of embedding IPython https://github.com/ipython/ipython/issues/12199

The following example would previously break in `gearbox tgshell` when running with embedded IPython.

This issue stems from the `ipython` library. The behaviour is reproducible outside of `tgshell` by embedding `ipython` in a regular REPL session.

```pycon
>>> import IPython
>>> IPython.embed()
Python 3.9.9 (main, Mar  4 2022, 20:56:50)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: x = 10

In [2]: def foo(): return x

In [3]: foo()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Input In [3], in <cell line: 1>()
----> 1 foo()

Input In [2], in foo()
----> 1 def foo(): return x

NameError: name 'x' is not defined

In [4]:
```

## In other frameworks

The flask package [flask-shell-ipython](https://github.com/ei-grad/flask-shell-ipython/blob/master/flask_shell_ipython.py#L26-L45) gets around this limitation by calling `IPython. start_ipython` instead of attempting to embed the interpreter. Take a look and their [implementation](https://github.com/ei-grad/flask-shell-ipython/blob/195ab1daeea8a9329b133cc7c4e43eabf2e45ae6/flask_shell_ipython.py#L26-L45)

Django does the same thing when you run `./manage.py shell` see [here](https://github.com/django/django/blob/0dd29209091280ccf34e07c9468746c396b7778e/django/core/management/commands/shell.py#L47-L50)

This PR attempts to add this behaviour to `gearbox tgshell`

I've naively assumed that the `gearbox tgshell` command doesn't depend the ipython session being embedded.